### PR TITLE
Empty trash and remove empty Compiler_Methods

### DIFF
--- a/Build4D/Project/Sources/Methods/Compiler_Methods.4dm
+++ b/Build4D/Project/Sources/Methods/Compiler_Methods.4dm
@@ -1,1 +1,0 @@
-//%attributes = {"invisible":true}

--- a/Build4D/Project/Sources/folders.json
+++ b/Build4D/Project/Sources/folders.json
@@ -18,27 +18,11 @@
 			"onStartup"
 		]
 	},
-	"...  compiler": {
-		"methods": [
-			"Compiler_Methods"
-		]
-	},
-	"(____ franck)": {},
-	"(____ test methods)": {},
-	"(. . settings private classes)": {},
-	"(. . test class)": {},
 	"coop -> preempt": {
 		"methods": [
 			"quit4D_coop",
 			"showOnDisk_coop"
 		]
 	},
-	"trash": {
-		"groups": [
-			"(____ franck)",
-			"(____ test methods)",
-			"(. . settings private classes)",
-			"(. . test class)"
-		]
-	}
+	"trash": {}
 }


### PR DESCRIPTION
any good reason to keep an empty Compiler_Methods.4dm?